### PR TITLE
Fix scroll bar experiences

### DIFF
--- a/app/_components/ui/Card/ExperiencesCard.tsx
+++ b/app/_components/ui/Card/ExperiencesCard.tsx
@@ -36,6 +36,7 @@ export const ExperiencesCard: React.FC<{
         experiences.map((experience, index) => (
           <div key={index}>
             <ScrollArea
+              type='always'
               className={cn(
                 cnBorder,
                 'w-full',

--- a/app/_components/ui/Card/ProjectsCard.tsx
+++ b/app/_components/ui/Card/ProjectsCard.tsx
@@ -12,7 +12,6 @@ import { Badge } from '@/lib/components/ui/badge';
 import { cn } from '@/lib/utils';
 
 import { dynamicMarginBottom } from '@/utils/dynamicMarginBottom';
-import { baseUrl } from '@/utils/constants/baseUrl';
 import { CardProps } from '@/types/CardProps';
 import { cnBorder } from '@/styles/borderStyles';
 import { cnFlexBetweenX, cnFlexCol } from '@/styles/flexStyles';

--- a/app/_components/ui/List/ExperiencesList.tsx
+++ b/app/_components/ui/List/ExperiencesList.tsx
@@ -26,13 +26,7 @@ export const ExperiencesList: React.FC<{
           size={28}
         />
         <div className={cn(cnFlexCol)}>
-          <h3
-            className={cn(
-              cnTitle3,
-              'xs:flex xs:flex-row',
-              lineThroughItem(date || '')
-            )}
-          >
+          <h3 className={cn(cnTitle3, 'xs:flex xs:flex-row')}>
             {title && capitalizeFirstLetterOfEachWord(title)}
             <span className={cn('block xs:flex', 'text-primary')}>
               &nbsp;@{' '}

--- a/app/_components/ui/List/ExperiencesList.tsx
+++ b/app/_components/ui/List/ExperiencesList.tsx
@@ -5,7 +5,6 @@ import {
   cnParagraph,
   cnTitle3,
 } from '@/styles/fontStyles';
-import { lineThroughItem } from '@/styles/lineThroughStyles';
 import { cnFlexCol } from '@/styles/flexStyles';
 import { cnMarginRight } from '@/styles/boxModelStyles';
 import { cn } from '@/lib/utils';


### PR DESCRIPTION
This pull request includes changes to the `ExperiencesCard`, `ProjectsCard`, and `ExperiencesList` components to improve code readability and maintainability by removing unused imports and adjusting component properties.

Code readability and maintainability improvements:

* [`app/_components/ui/Card/ProjectsCard.tsx`](diffhunk://#diff-abb72c469bf0dad35c0919426da791608b2a3be13b067ab3ed6372854972abcaL15): Removed the unused `baseUrl` import to clean up the code.
* [`app/_components/ui/List/ExperiencesList.tsx`](diffhunk://#diff-622ed304540a23b26284140c53b9f9b7c2231a4078c81385f79dc47c556e5f24L8): Removed the unused `lineThroughItem` import to clean up the code.

Component property adjustments:

* [`app/_components/ui/Card/ExperiencesCard.tsx`](diffhunk://#diff-1296dd54e1193c16672892436da71036a7a4b6ad427c67b8076879f69e7daaf4R39): Added the `type='always'` property to the `ScrollArea` component to ensure the scrollbar is always visible.
* [`app/_components/ui/List/ExperiencesList.tsx`](diffhunk://#diff-622ed304540a23b26284140c53b9f9b7c2231a4078c81385f79dc47c556e5f24L29-R28): Simplified the `h3` element by removing the `lineThroughItem` class and its associated logic.