### PR TITLE
fix: send mail with gmail for deploy

### DIFF
--- a/src/config/gmailAuth.config.ts
+++ b/src/config/gmailAuth.config.ts
@@ -1,10 +1,13 @@
 import dotenv from 'dotenv';
 import { google } from 'googleapis';
-dotenv.config(
-  process.env.NODE_ENV === 'development'
-    ? { path: '.env.development.local' }
-    : { path: '.env.production' }
-);
+dotenv.config({
+  path:
+    process.env.NODE_ENV === 'development'
+      ? '.env.development.local'
+      : process.env.NODE_ENV === 'production'
+        ? '.env.production'
+        : '.env',
+});
 
 const oAuth2Client = new google.auth.OAuth2(
   process.env.GMAIL_CLIENT_ID,


### PR DESCRIPTION
This pull request includes an update to the `dotenv` configuration in the `src/config/gmailAuth.config.ts` file. The change ensures that the correct environment file is loaded based on the `NODE_ENV` variable.

Configuration update:

* [`src/config/gmailAuth.config.ts`](diffhunk://#diff-de92604c31406d5867934431cd8346ec9360e5a1b04b6be8bea8ebdcae259876L3-R10): Modified the `dotenv.config` call to use an object with a `path` property, ensuring the correct `.env` file is loaded for 'development' and 'production' environments. If `NODE_ENV` is not set to 'development' or 'production', the default `.env` file is used.